### PR TITLE
fix: cdk install and classes instantiation

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -21,7 +21,7 @@
   "defaults": {
     "build": {
       "args": "",
-      "packtool": ""
+      "packtool": "mops sources"
     }
   },
   "output_env_file": ".env",

--- a/mops.toml
+++ b/mops.toml
@@ -7,5 +7,8 @@ keywords = [ ]
 license = "MIT"
 
 [dependencies]
-base = "0.9.3"
-ic-websocket-cdk-mo = "https://github.com/omnia-network/ic-websocket-cdk-mo#c9970f76e74a9019f2a5c97b317b84b9cc13d808"
+base = "0.9.1"
+ic-certification = "0.1.1"
+sha2 = "0.0.2"
+cbor = "0.1.3"
+ic-websocket-cdk = "https://github.com/omnia-network/ic-websocket-cdk-mo#1d3320626e3c476632fc46ebdb9b5402e6207999"

--- a/src/websocket_motoko_backend/main.mo
+++ b/src/websocket_motoko_backend/main.mo
@@ -1,49 +1,59 @@
-import IcWebSocket "mo:ic-websocket-cdk-mo";
+import IcWebSocketCdk "mo:ic-websocket-cdk";
 import Text "mo:base/Text";
 import Debug "mo:base/Debug";
 
 actor {
+  // Paste here the principal of the gateway obtained when running the gateway
+  let gateway_principal : Text = "iooeh-5tqqn-c3ego-oav3s-lvcwe-xuybn-e26kv-cblbg-a2axl-lor3f-fae";
 
-  public type AppMessage = {
+  type AppMessage = {
     message : Text;
+  };
+
+  var ws_state = IcWebSocketCdk.IcWebSocketState(gateway_principal);
+
+  /// A custom function to send the message to the client
+  func send_app_message(client_key : IcWebSocketCdk.ClientPublicKey, msg : AppMessage): async () {
+    Debug.print("Sending message: " # debug_show (msg));
+
+    // here we call the ws_send from the CDK!!
+    switch (await IcWebSocketCdk.ws_send(ws_state, client_key, to_candid(msg))) {
+      case (#Err(err)) {
+        Debug.print("Could not send message:" # debug_show (#Err(err)));
+      };
+      case (_) {};
+    };
   };
 
   func on_open(args : IcWebSocketCdk.OnOpenCallbackArgs) : async () {
     let message : AppMessage = {
       message = "Ping";
     };
-    send_app_message(args.client_key, message);
+    await send_app_message(args.client_key, message);
   };
 
   /// The custom logic is just a ping-pong message exchange between frontend and canister.
   /// Note that the message from the WebSocket is serialized in CBOR, so we have to deserialize it first
 
-  public func on_message(args : IcWebSocketCdk.OnMessageCallbackArgs) : async () {
-    let app_msg : AppMessage = {
-      message = Text.decodeUtf8(args.message);
+  func on_message(args : IcWebSocketCdk.OnMessageCallbackArgs) : async () {
+    let app_msg : ?AppMessage = from_candid(args.message);
+    let new_msg: AppMessage = switch (app_msg) {
+      case (?msg) { 
+        { message = Text.concat(msg.message, " ping") };
+      };
+      case (null) {
+        Debug.print("Could not deserialize message");
+        return;
+      };
     };
-    let new_msg = AppMessage { text = Text.concat(app_msg.text, " ping") };
 
-    Debug.print(Text.concat("Received message: " # debug_show (new_msg)));
+    Debug.print("Received message: " # debug_show (new_msg));
 
-    send_app_message(args.client_key, new_msg);
+    await send_app_message(args.client_key, new_msg);
   };
 
   func on_close(args : IcWebSocketCdk.OnCloseCallbackArgs) : async () {
     Debug.print("Client " # debug_show (args.client_key) # " disconnected");
-  };
-
-  /// A custom function to send the message to the client
-  func send_app_message(client_key : IcWebSocketCdk.ClientPublicKey, msg : AppMessage) {
-    Debug.print("Sending message: " # debug_show (msg));
-
-    // here we call the ws_send from the CDK!!
-    switch (IcWebSocketCdk.ws_send(client_key, msg)) {
-      case (#Err(err)) {
-        Debug.print("Could not send message:" # debug_show (#Err(err)));
-      };
-      case (_) {};
-    };
   };
 
   let handlers = IcWebSocketCdk.WsHandlers(
@@ -52,33 +62,31 @@ actor {
     ?on_close,
   );
 
-  // Paste here the principal of the gateway obtained when running the gateway
-  let gateway_principal : Text = "iooeh-5tqqn-c3ego-oav3s-lvcwe-xuybn-e26kv-cblbg-a2axl-lor3f-fae";
-
-  var ws = IcWebSocketCdk.IcWebSocket(handlers, gateway_principal);
+  var ws = IcWebSocketCdk.IcWebSocket(handlers, ws_state);
 
   system func postupgrade() {
-    ws := IcWebSocketCdk.IcWebSocket(handlers, gateway_principal);
+    ws_state := IcWebSocketCdk.IcWebSocketState(gateway_principal);
+    ws := IcWebSocketCdk.IcWebSocket(handlers, ws_state);
   };
 
   // method called by the client SDK when instantiating a new IcWebSocket
   public shared ({ caller }) func ws_register(args : IcWebSocketCdk.CanisterWsRegisterArguments) : async IcWebSocketCdk.CanisterWsRegisterResult {
-    ws.ws_register(caller, args);
+    await ws.ws_register(caller, args);
   };
 
   // method called by the WS Gateway after receiving FirstMessage from the client
   public shared ({ caller }) func ws_open(args : IcWebSocketCdk.CanisterWsOpenArguments) : async IcWebSocketCdk.CanisterWsOpenResult {
-    ws.ws_open(caller, args);
+    await ws.ws_open(caller, args);
   };
 
   // method called by the Ws Gateway when closing the IcWebSocket connection
   public shared ({ caller }) func ws_close(args : IcWebSocketCdk.CanisterWsCloseArguments) : async IcWebSocketCdk.CanisterWsCloseResult {
-    ws.ws_close(caller, args);
+    await ws.ws_close(caller, args);
   };
 
   // method called by the frontend SDK to send a message to the canister
   public shared ({ caller }) func ws_message(args : IcWebSocketCdk.CanisterWsMessageArguments) : async IcWebSocketCdk.CanisterWsMessageResult {
-    ws.ws_message(caller, args);
+    await ws.ws_message(caller, args);
   };
 
   // method called by the WS Gateway to get messages for all the clients it serves


### PR DESCRIPTION
With these fixes it should work.

Please note that I have added the candid serialization to the message [when it's sent](https://github.com/Luca8991/websockets-motoko/blob/6c0f8d97f119355df414b006b94afff3ef561aa4/src/websocket_motoko_backend/main.mo#L20) and deserialization [when it's received](https://github.com/Luca8991/websockets-motoko/blob/6c0f8d97f119355df414b006b94afff3ef561aa4/src/websocket_motoko_backend/main.mo#L39).
This means that on the frontend you have to do the same. As a guideline, you can follow the [Rust example](https://github.com/omnia-network/ic_websocket_example/blob/cbfd55eb404696f59c32f941c55f406c608ed4e7/src/ic_websocket_example_frontend/src/main.ts#L83-L122), paying attention to the [serializeAppMessage](https://github.com/omnia-network/ic_websocket_example/blob/cbfd55eb404696f59c32f941c55f406c608ed4e7/src/ic_websocket_example_frontend/src/utils/idl.ts#L9-L11) and [deserializeAppMessage](https://github.com/omnia-network/ic_websocket_example/blob/cbfd55eb404696f59c32f941c55f406c608ed4e7/src/ic_websocket_example_frontend/src/utils/idl.ts#L13-L15) functions.